### PR TITLE
Verwijder security contact link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,9 +3,6 @@ contact_links:
   - name: Vragen en discussies / Questions and discussions
     url: https://github.com/MinBZK/MijnOverheidZakelijk/discussions
     about: Stel hier je vraag / Ask your question here
-  - name: Beveiligingsproblemen / Security issues
-    url: https://github.com/MinBZK/MijnOverheidZakelijk/security/policy
-    about: Meld beveiligingsproblemen niet via issues / Do not report security issues here
   - name: Contact MOZa
     url: https://mijnoverheidzakelijk.nl/contact/
     about: Neem rechtstreeks contact op met het MOZa-team / Contact the MOZa team directly


### PR DESCRIPTION
## Type wijziging / Type of change

- [x] Bug fix
- [ ] Nieuwe functionaliteit / New feature
- [ ] Refactoring
- [ ] Documentatie / Documentation
- [ ] Anders / Other

## Samenvatting / Summary

Omdat we (vanuit MinBZK) een SECURITY.md hebben, genereert GitHub zelf een link naar deze pagina. Een eigen toevoegen maakt het dubbel en onduidelijk.
